### PR TITLE
Ia 4265 pass ad creative ad

### DIFF
--- a/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/CustomEventBanner.java
+++ b/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/CustomEventBanner.java
@@ -2,7 +2,10 @@ package com.mopub.mobileads;
 
 import android.content.Context;
 import android.support.annotation.CallSuper;
+import android.support.annotation.Nullable;
 import android.view.View;
+
+import com.mopub.mobileads.events.AdCreativeIdBundle;
 
 import java.util.Map;
 
@@ -66,7 +69,7 @@ public abstract class CustomEventBanner {
          * needs to display the provided View. Failure to do so will disrupt the mediation waterfall
          * and cause future ad requests to stall.
          */
-        void onBannerLoaded(View bannerView);
+        void onBannerLoaded(View bannerView, @Nullable AdCreativeIdBundle adCreativeIdBundle);
         
         /*
          * Your custom event subclass must call this method when it fails to load an ad.

--- a/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/CustomEventBannerAdapter.java
+++ b/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/CustomEventBannerAdapter.java
@@ -12,6 +12,7 @@ import com.mopub.common.Preconditions;
 import com.mopub.common.logging.MoPubLog;
 import com.mopub.common.util.ReflectionTarget;
 import com.mopub.mobileads.CustomEventBanner.CustomEventBannerListener;
+import com.mopub.mobileads.events.AdCreativeIdBundle;
 import com.mopub.mobileads.factories.CustomEventBannerFactory;
 
 import java.util.Map;
@@ -26,134 +27,134 @@ import static com.mopub.mobileads.MoPubErrorCode.NETWORK_TIMEOUT;
 import static com.mopub.mobileads.MoPubErrorCode.UNSPECIFIED;
 
 public class CustomEventBannerAdapter implements CustomEventBannerListener {
-    public static final int DEFAULT_BANNER_TIMEOUT_DELAY = Constants.SIX_SECONDS_MILLIS;
-    private boolean mInvalidated;
-    private MoPubView mMoPubView;
-    private Context mContext;
-    private CustomEventBanner mCustomEventBanner;
-    private Map<String, Object> mLocalExtras;
-    private Map<String, String> mServerExtras;
-
-    private final Handler mHandler;
-    private final Runnable mTimeout;
-    private boolean mStoredAutorefresh;
-
-    public CustomEventBannerAdapter(@NonNull MoPubView moPubView,Context context,
-            @NonNull String className,
-            @NonNull Map<String, String> serverExtras,
-            long broadcastIdentifier,
-            @Nullable AdReport adReport) {
-        Preconditions.checkNotNull(serverExtras);
-        mHandler = new Handler();
-        mMoPubView = moPubView;
-        mContext = context;
-        mTimeout = new Runnable() {
-            @Override
-            public void run() {
-               onBannerTimed();
-            }
-        };
-
-        MoPubLog.d("Attempting to invoke custom event: " + className);
-        try {
-            mCustomEventBanner = CustomEventBannerFactory.create(className);
-        } catch (Exception exception) {
-            MoPubLog.d("Couldn't locate or instantiate custom event: " + className + ".");
-            mMoPubView.loadFailUrl(ADAPTER_NOT_FOUND);
-            return;
-        }
-
-        // Attempt to load the JSON extras into mServerExtras.
-        mServerExtras = new TreeMap<String, String>(serverExtras);
-
-        mLocalExtras = mMoPubView.getLocalExtras();
-        if (mMoPubView.getLocation() != null) {
-            mLocalExtras.put("location", mMoPubView.getLocation());
-        }
-        mLocalExtras.put(BROADCAST_IDENTIFIER_KEY, broadcastIdentifier);
-        mLocalExtras.put(AD_REPORT_KEY, adReport);
-        mLocalExtras.put(AD_WIDTH, mMoPubView.getAdWidth());
-        mLocalExtras.put(AD_HEIGHT, mMoPubView.getAdHeight());
-    }
-
-    @ReflectionTarget
-    void loadAd() {
-        if (isInvalidated() || mCustomEventBanner == null) {
-            return;
-        }
-
-        mHandler.postDelayed(mTimeout, getTimeoutDelayMilliseconds());
-
-        // Custom event classes can be developed by any third party and may not be tested.
-        // We catch all exceptions here to prevent crashes from untested code.
-        try {
-            mCustomEventBanner.loadBanner(mContext, this, mLocalExtras, mServerExtras);
-        } catch (Exception e) {
-            MoPubLog.d("Loading a custom event banner threw an exception.", e);
-            onBannerFailed(MoPubErrorCode.INTERNAL_ERROR);
-        }
-    }
-
-    @ReflectionTarget
-    void invalidate() {
-        if (mCustomEventBanner != null) {
-            // Custom event classes can be developed by any third party and may not be tested.
-            // We catch all exceptions here to prevent crashes from untested code.
-            try {
-                mCustomEventBanner.onInvalidate();
-            } catch (Exception e) {
-                MoPubLog.d("Invalidating a custom event banner threw an exception", e);
-            }
-        }
-        mContext = null;
-        mCustomEventBanner = null;
-        mLocalExtras = null;
-        mServerExtras = null;
-        mInvalidated = true;
-    }
-
-    @ReflectionTarget
-    void stop(){
-        if (mCustomEventBanner != null) {
-            try {
-                mCustomEventBanner.onStop();
-            } catch (Exception e) {
-                MoPubLog.d("Stopping a custom event banner threw an exception", e);
-            }
-        }
-    }
-
-    @ReflectionTarget
-    void pause(){
-        if (mCustomEventBanner != null) {
-            try {
-                mCustomEventBanner.onPause();
-            } catch (Exception e) {
-                MoPubLog.d("Stopping a custom event banner threw an exception", e);
-            }
-        }
-    }
-
-    @ReflectionTarget
-    void resume(){
-        if (mCustomEventBanner != null) {
-            try {
-                mCustomEventBanner.onResume();
-            } catch (Exception e) {
-                MoPubLog.d("Stopping a custom event banner threw an exception", e);
-            }
-        }
-    }
-
-    boolean isInvalidated() {
-        return mInvalidated;
-    }
-
-    private void cancelTimeout() {
-        mHandler.removeCallbacks(mTimeout);
-    }
-
-    private int getTimeoutDelayMilliseconds() {
+	public static final int DEFAULT_BANNER_TIMEOUT_DELAY = Constants.SIX_SECONDS_MILLIS;
+	private boolean mInvalidated;
+	private MoPubView mMoPubView;
+	private Context mContext;
+	private CustomEventBanner mCustomEventBanner;
+	private Map<String, Object> mLocalExtras;
+	private Map<String, String> mServerExtras;
+	
+	private final Handler mHandler;
+	private final Runnable mTimeout;
+	private boolean mStoredAutorefresh;
+	
+	public CustomEventBannerAdapter(@NonNull MoPubView moPubView, Context context,
+	                                @NonNull String className,
+	                                @NonNull Map<String, String> serverExtras,
+	                                long broadcastIdentifier,
+	                                @Nullable AdReport adReport) {
+		Preconditions.checkNotNull(serverExtras);
+		mHandler = new Handler();
+		mMoPubView = moPubView;
+		mContext = context;
+		mTimeout = new Runnable() {
+			@Override
+			public void run() {
+				onBannerTimed();
+			}
+		};
+		
+		MoPubLog.d("Attempting to invoke custom event: " + className);
+		try {
+			mCustomEventBanner = CustomEventBannerFactory.create(className);
+		} catch (Exception exception) {
+			MoPubLog.d("Couldn't locate or instantiate custom event: " + className + ".");
+			mMoPubView.loadFailUrl(ADAPTER_NOT_FOUND);
+			return;
+		}
+		
+		// Attempt to load the JSON extras into mServerExtras.
+		mServerExtras = new TreeMap<String, String>(serverExtras);
+		
+		mLocalExtras = mMoPubView.getLocalExtras();
+		if (mMoPubView.getLocation() != null) {
+			mLocalExtras.put("location", mMoPubView.getLocation());
+		}
+		mLocalExtras.put(BROADCAST_IDENTIFIER_KEY, broadcastIdentifier);
+		mLocalExtras.put(AD_REPORT_KEY, adReport);
+		mLocalExtras.put(AD_WIDTH, mMoPubView.getAdWidth());
+		mLocalExtras.put(AD_HEIGHT, mMoPubView.getAdHeight());
+	}
+	
+	@ReflectionTarget
+	void loadAd() {
+		if (isInvalidated() || mCustomEventBanner == null) {
+			return;
+		}
+		
+		mHandler.postDelayed(mTimeout, getTimeoutDelayMilliseconds());
+		
+		// Custom event classes can be developed by any third party and may not be tested.
+		// We catch all exceptions here to prevent crashes from untested code.
+		try {
+			mCustomEventBanner.loadBanner(mContext, this, mLocalExtras, mServerExtras);
+		} catch (Exception e) {
+			MoPubLog.d("Loading a custom event banner threw an exception.", e);
+			onBannerFailed(MoPubErrorCode.INTERNAL_ERROR);
+		}
+	}
+	
+	@ReflectionTarget
+	void invalidate() {
+		if (mCustomEventBanner != null) {
+			// Custom event classes can be developed by any third party and may not be tested.
+			// We catch all exceptions here to prevent crashes from untested code.
+			try {
+				mCustomEventBanner.onInvalidate();
+			} catch (Exception e) {
+				MoPubLog.d("Invalidating a custom event banner threw an exception", e);
+			}
+		}
+		mContext = null;
+		mCustomEventBanner = null;
+		mLocalExtras = null;
+		mServerExtras = null;
+		mInvalidated = true;
+	}
+	
+	@ReflectionTarget
+	void stop() {
+		if (mCustomEventBanner != null) {
+			try {
+				mCustomEventBanner.onStop();
+			} catch (Exception e) {
+				MoPubLog.d("Stopping a custom event banner threw an exception", e);
+			}
+		}
+	}
+	
+	@ReflectionTarget
+	void pause() {
+		if (mCustomEventBanner != null) {
+			try {
+				mCustomEventBanner.onPause();
+			} catch (Exception e) {
+				MoPubLog.d("Stopping a custom event banner threw an exception", e);
+			}
+		}
+	}
+	
+	@ReflectionTarget
+	void resume() {
+		if (mCustomEventBanner != null) {
+			try {
+				mCustomEventBanner.onResume();
+			} catch (Exception e) {
+				MoPubLog.d("Stopping a custom event banner threw an exception", e);
+			}
+		}
+	}
+	
+	boolean isInvalidated() {
+		return mInvalidated;
+	}
+	
+	private void cancelTimeout() {
+		mHandler.removeCallbacks(mTimeout);
+	}
+	
+	private int getTimeoutDelayMilliseconds() {
 //        if (mMoPubView == null
 //                || mMoPubView.getAdTimeoutDelay() == null
 //                || mMoPubView.getAdTimeoutDelay() < 0) {
@@ -161,84 +162,85 @@ public class CustomEventBannerAdapter implements CustomEventBannerListener {
 //        }
 //
 //        return mMoPubView.getAdTimeoutDelay() * 1000;
-        return DEFAULT_BANNER_TIMEOUT_DELAY;
-    }
-
-    /*
-     * CustomEventBanner.Listener implementation
-     */
-    @Override
-    public void onBannerLoaded(View bannerView) {
-        if (isInvalidated()) {
-            return;
-        }
-
-        cancelTimeout();
-
-        if (mMoPubView != null) {
-            mMoPubView.nativeAdLoaded();
-            mMoPubView.setAdContentView(bannerView);
-            if (!(bannerView instanceof HtmlBannerWebView)) {
-                mMoPubView.trackNativeImpression();
-            }
-        }
-    }
-
-    private void onBannerTimed(){
-        MoPubLog.d("Third-party network timed out.");
-        onBannerFailed(NETWORK_TIMEOUT);
-        invalidate();
-    }
-
-    @Override
-    public void onBannerFailed(MoPubErrorCode errorCode) {
-        if (isInvalidated()) {
-            return;
-        }
-
-        if (mMoPubView != null) {
-            if (errorCode == null) {
-                errorCode = UNSPECIFIED;
-            }
-            cancelTimeout();
-            mMoPubView.loadFailUrl(errorCode);
-        }
-    }
-
-    @Override
-    public void onBannerExpanded() {
-        if (isInvalidated()) {
-            return;
-        }
-
-        mStoredAutorefresh = mMoPubView.getAutorefreshEnabled();
-        mMoPubView.setAutorefreshEnabled(false);
-        mMoPubView.adPresentedOverlay();
-    }
-
-    @Override
-    public void onBannerCollapsed() {
-        if (isInvalidated()) {
-            return;
-        }
-
-        mMoPubView.setAutorefreshEnabled(mStoredAutorefresh);
-        mMoPubView.adClosed();
-    }
-
-    @Override
-    public void onBannerClicked() {
-        if (isInvalidated()) {
-            return;
-        }
-
-        if (mMoPubView != null) {
-            mMoPubView.registerClick();
-        }
-    }
-
-    @Override
-    public void onLeaveApplication() {
-        onBannerClicked();
-    }
+		return DEFAULT_BANNER_TIMEOUT_DELAY;
+	}
+	
+	/*
+	 * CustomEventBanner.Listener implementation
+	 */
+	@Override
+	public void onBannerLoaded(final View bannerView, @Nullable final AdCreativeIdBundle adCreativeIdBundle) {
+		if (isInvalidated()) {
+			return;
+		}
+		
+		cancelTimeout();
+		
+		if (mMoPubView != null) {
+			mMoPubView.setAdContentView(bannerView);
+			mMoPubView.setAdCreativeId(adCreativeIdBundle);
+			mMoPubView.nativeAdLoaded();
+			if (!(bannerView instanceof HtmlBannerWebView)) {
+				mMoPubView.trackNativeImpression();
+			}
+		}
+	}
+	
+	private void onBannerTimed() {
+		MoPubLog.d("Third-party network timed out.");
+		onBannerFailed(NETWORK_TIMEOUT);
+		invalidate();
+	}
+	
+	@Override
+	public void onBannerFailed(MoPubErrorCode errorCode) {
+		if (isInvalidated()) {
+			return;
+		}
+		
+		if (mMoPubView != null) {
+			if (errorCode == null) {
+				errorCode = UNSPECIFIED;
+			}
+			cancelTimeout();
+			mMoPubView.loadFailUrl(errorCode);
+		}
+	}
+	
+	@Override
+	public void onBannerExpanded() {
+		if (isInvalidated()) {
+			return;
+		}
+		
+		mStoredAutorefresh = mMoPubView.getAutorefreshEnabled();
+		mMoPubView.setAutorefreshEnabled(false);
+		mMoPubView.adPresentedOverlay();
+	}
+	
+	@Override
+	public void onBannerCollapsed() {
+		if (isInvalidated()) {
+			return;
+		}
+		
+		mMoPubView.setAutorefreshEnabled(mStoredAutorefresh);
+		mMoPubView.adClosed();
+	}
+	
+	@Override
+	public void onBannerClicked() {
+		if (isInvalidated()) {
+			return;
+		}
+		
+		if (mMoPubView != null) {
+			mMoPubView.registerClick();
+		}
+	}
+	
+	@Override
+	public void onLeaveApplication() {
+		onBannerClicked();
+	}
 }

--- a/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/HtmlBannerWebView.java
+++ b/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/HtmlBannerWebView.java
@@ -28,7 +28,7 @@ public class HtmlBannerWebView extends BaseHtmlWebView {
 
         @Override
         public void onLoaded(BaseHtmlWebView htmlWebView) {
-            mCustomEventBannerListener.onBannerLoaded(htmlWebView);
+            mCustomEventBannerListener.onBannerLoaded(htmlWebView, null);
         }
 
         @Override

--- a/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/HtmlBannerWebView.java
+++ b/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/HtmlBannerWebView.java
@@ -1,50 +1,64 @@
 package com.mopub.mobileads;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import com.mopub.common.AdReport;
+import com.mopub.mobileads.events.MopubAdCreativeId;
 
 import static com.mopub.mobileads.CustomEventBanner.CustomEventBannerListener;
 
 public class HtmlBannerWebView extends BaseHtmlWebView {
-    public static final String EXTRA_AD_CLICK_DATA = "com.mopub.intent.extra.AD_CLICK_DATA";
-
-    public HtmlBannerWebView(Context context, AdReport adReport) {
-        super(context, adReport);
-    }
-
-    public void init(CustomEventBannerListener customEventBannerListener, boolean isScrollable, String redirectUrl, String clickthroughUrl, String dspCreativeId) {
-        super.init(isScrollable);
-
-        setWebViewClient(new HtmlWebViewClient(new HtmlBannerWebViewListener(customEventBannerListener), this, clickthroughUrl, redirectUrl, dspCreativeId));
-    }
-
-    static class HtmlBannerWebViewListener implements HtmlWebViewListener {
-        private final CustomEventBannerListener mCustomEventBannerListener;
-
-        public HtmlBannerWebViewListener(CustomEventBannerListener customEventBannerListener) {
-            mCustomEventBannerListener = customEventBannerListener;
-        }
-
-        @Override
-        public void onLoaded(BaseHtmlWebView htmlWebView) {
-            mCustomEventBannerListener.onBannerLoaded(htmlWebView, null);
-        }
-
-        @Override
-        public void onFailed(MoPubErrorCode errorCode) {
-            mCustomEventBannerListener.onBannerFailed(errorCode);
-        }
-
-        @Override
-        public void onClicked() {
-            mCustomEventBannerListener.onBannerClicked();
-        }
-
-        @Override
-        public void onCollapsed() {
-            mCustomEventBannerListener.onBannerCollapsed();
-        }
-
-    }
+	public static final String EXTRA_AD_CLICK_DATA = "com.mopub.intent.extra.AD_CLICK_DATA";
+	
+	public HtmlBannerWebView(Context context, AdReport adReport) {
+		super(context, adReport);
+	}
+	
+	public void init(CustomEventBannerListener customEventBannerListener, boolean isScrollable, String redirectUrl, String clickthroughUrl,
+	                 String dspCreativeId) {
+		super.init(isScrollable);
+		
+		setWebViewClient(
+				new HtmlWebViewClient(new HtmlBannerWebViewListener(customEventBannerListener, dspCreativeId), this, clickthroughUrl,
+						redirectUrl,
+						dspCreativeId));
+	}
+	
+	static class HtmlBannerWebViewListener implements HtmlWebViewListener {
+		private final CustomEventBannerListener mCustomEventBannerListener;
+		@Nullable
+		private final String mDspCreativeId;
+		
+		public HtmlBannerWebViewListener(CustomEventBannerListener customEventBannerListener, @Nullable String dspCreativeId) {
+			mCustomEventBannerListener = customEventBannerListener;
+			mDspCreativeId = dspCreativeId;
+		}
+		
+		@Override
+		public void onLoaded(BaseHtmlWebView htmlWebView) {
+			MopubAdCreativeId mopubAdCreativeId = null;
+			if (!TextUtils.isEmpty(mDspCreativeId)) {
+				mopubAdCreativeId = new MopubAdCreativeId(mDspCreativeId);
+			}
+			mCustomEventBannerListener.onBannerLoaded(htmlWebView, mopubAdCreativeId);
+		}
+		
+		@Override
+		public void onFailed(MoPubErrorCode errorCode) {
+			mCustomEventBannerListener.onBannerFailed(errorCode);
+		}
+		
+		@Override
+		public void onClicked() {
+			mCustomEventBannerListener.onBannerClicked();
+		}
+		
+		@Override
+		public void onCollapsed() {
+			mCustomEventBannerListener.onBannerCollapsed();
+		}
+		
+	}
 }

--- a/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mraid/MraidBanner.java
+++ b/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mraid/MraidBanner.java
@@ -56,7 +56,7 @@ class MraidBanner extends CustomEventBanner {
             public void onLoaded(View view) {
                 // Honoring the server dimensions forces the WebView to be the size of the banner
                 AdViewController.setShouldHonorServerDimensions(view);
-                mBannerListener.onBannerLoaded(view);
+                mBannerListener.onBannerLoaded(view, null);
             }
 
             @Override

--- a/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mraid/MraidBanner.java
+++ b/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mraid/MraidBanner.java
@@ -3,6 +3,7 @@ package com.mopub.mraid;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import android.view.View;
 
 import com.mopub.common.AdReport;
@@ -10,6 +11,7 @@ import com.mopub.common.VisibleForTesting;
 import com.mopub.common.logging.MoPubLog;
 import com.mopub.mobileads.AdViewController;
 import com.mopub.mobileads.CustomEventBanner;
+import com.mopub.mobileads.events.MopubAdCreativeId;
 import com.mopub.mobileads.factories.MraidControllerFactory;
 import com.mopub.mraid.MraidController.MraidListener;
 
@@ -20,100 +22,104 @@ import static com.mopub.common.DataKeys.HTML_RESPONSE_BODY_KEY;
 import static com.mopub.mobileads.MoPubErrorCode.MRAID_LOAD_ERROR;
 
 class MraidBanner extends CustomEventBanner {
-
-    @Nullable private MraidController mMraidController;
-    @Nullable private CustomEventBannerListener mBannerListener;
-    @Nullable private MraidWebViewDebugListener mDebugListener;
-
-    @Override
-    protected void loadBanner(@NonNull Context context,
-                    @NonNull CustomEventBannerListener customEventBannerListener,
-                    @NonNull Map<String, Object> localExtras,
-                    @NonNull Map<String, String> serverExtras) {
-        mBannerListener = customEventBannerListener;
-
-        String htmlData;
-        if (extrasAreValid(serverExtras)) {
-            htmlData = serverExtras.get(HTML_RESPONSE_BODY_KEY);
-        } else {
-            mBannerListener.onBannerFailed(MRAID_LOAD_ERROR);
-            return;
-        }
-
-        try {
-            AdReport adReport = (AdReport) localExtras.get(AD_REPORT_KEY);
-            mMraidController = MraidControllerFactory.create(
-                    context, adReport, PlacementType.INLINE);
-        } catch (ClassCastException e) {
-            MoPubLog.w("MRAID banner creating failed:", e);
-            mBannerListener.onBannerFailed(MRAID_LOAD_ERROR);
-            return;
-        }
-
-        mMraidController.setDebugListener(mDebugListener);
-        mMraidController.setMraidListener(new MraidListener() {
-            @Override
-            public void onLoaded(View view) {
-                // Honoring the server dimensions forces the WebView to be the size of the banner
-                AdViewController.setShouldHonorServerDimensions(view);
-                mBannerListener.onBannerLoaded(view, null);
-            }
-
-            @Override
-            public void onFailedToLoad() {
-                mBannerListener.onBannerFailed(MRAID_LOAD_ERROR);
-            }
-
-            @Override
-            public void onExpand() {
-                mBannerListener.onBannerExpanded();
-                mBannerListener.onBannerClicked();
-            }
-
-            @Override
-            public void onOpen() {
-                mBannerListener.onBannerClicked();
-            }
-
-            @Override
-            public void onClose() {
-                mBannerListener.onBannerCollapsed();
-            }
-
-            @Override
-            public void onDirectClick() {
-                mBannerListener.onBannerClicked();
-            }
-        });
-        mMraidController.loadContent(htmlData);
-    }
-
-    @Override
-    protected void onInvalidate() {
-        super.onInvalidate();
-        if (mMraidController != null) {
-            mMraidController.setMraidListener(null);
-            mMraidController.destroy();
-        }
-    }
-
-    private boolean extrasAreValid(Map<String, String> serverExtras) {
-        return serverExtras.containsKey(HTML_RESPONSE_BODY_KEY);
-    }
-    
-    @Override
-    protected void onPause() {
-	    if (mMraidController != null) {
-		    mMraidController.onPause();
-	    }
-    }
-    
-    @Override
-    protected void onResume() {
-	    if (mMraidController != null) {
-		    mMraidController.onResume();
-	    }
-    }
+	
+	@Nullable private MraidController mMraidController;
+	@Nullable private CustomEventBannerListener mBannerListener;
+	@Nullable private MraidWebViewDebugListener mDebugListener;
+	
+	@Override
+	protected void loadBanner(@NonNull Context context,
+	                          @NonNull CustomEventBannerListener customEventBannerListener,
+	                          @NonNull Map<String, Object> localExtras,
+	                          @NonNull Map<String, String> serverExtras) {
+		mBannerListener = customEventBannerListener;
+		
+		String htmlData;
+		if (extrasAreValid(serverExtras)) {
+			htmlData = serverExtras.get(HTML_RESPONSE_BODY_KEY);
+		} else {
+			mBannerListener.onBannerFailed(MRAID_LOAD_ERROR);
+			return;
+		}
+		final AdReport adReport;
+		try {
+			adReport = (AdReport) localExtras.get(AD_REPORT_KEY);
+			mMraidController = MraidControllerFactory.create(
+					context, adReport, PlacementType.INLINE);
+		} catch (ClassCastException e) {
+			MoPubLog.w("MRAID banner creating failed:", e);
+			mBannerListener.onBannerFailed(MRAID_LOAD_ERROR);
+			return;
+		}
+		
+		mMraidController.setDebugListener(mDebugListener);
+		mMraidController.setMraidListener(new MraidListener() {
+			@Override
+			public void onLoaded(View view) {
+				// Honoring the server dimensions forces the WebView to be the size of the banner
+				AdViewController.setShouldHonorServerDimensions(view);
+				MopubAdCreativeId creativeId = null;
+				if (adReport != null && !TextUtils.isEmpty(adReport.getDspCreativeId())) {
+					creativeId = new MopubAdCreativeId(adReport.getDspCreativeId());
+				}
+				mBannerListener.onBannerLoaded(view, creativeId);
+			}
+			
+			@Override
+			public void onFailedToLoad() {
+				mBannerListener.onBannerFailed(MRAID_LOAD_ERROR);
+			}
+			
+			@Override
+			public void onExpand() {
+				mBannerListener.onBannerExpanded();
+				mBannerListener.onBannerClicked();
+			}
+			
+			@Override
+			public void onOpen() {
+				mBannerListener.onBannerClicked();
+			}
+			
+			@Override
+			public void onClose() {
+				mBannerListener.onBannerCollapsed();
+			}
+			
+			@Override
+			public void onDirectClick() {
+				mBannerListener.onBannerClicked();
+			}
+		});
+		mMraidController.loadContent(htmlData);
+	}
+	
+	@Override
+	protected void onInvalidate() {
+		super.onInvalidate();
+		if (mMraidController != null) {
+			mMraidController.setMraidListener(null);
+			mMraidController.destroy();
+		}
+	}
+	
+	private boolean extrasAreValid(Map<String, String> serverExtras) {
+		return serverExtras.containsKey(HTML_RESPONSE_BODY_KEY);
+	}
+	
+	@Override
+	protected void onPause() {
+		if (mMraidController != null) {
+			mMraidController.onPause();
+		}
+	}
+	
+	@Override
+	protected void onResume() {
+		if (mMraidController != null) {
+			mMraidController.onResume();
+		}
+	}
 	
 	@Override
 	protected void onStop() {
@@ -123,10 +129,10 @@ class MraidBanner extends CustomEventBanner {
 	}
 	
 	@VisibleForTesting
-    public void setDebugListener(@Nullable MraidWebViewDebugListener debugListener) {
-        mDebugListener = debugListener;
-        if (mMraidController != null) {
-            mMraidController.setDebugListener(debugListener);
-        }
-    }
+	public void setDebugListener(@Nullable MraidWebViewDebugListener debugListener) {
+		mDebugListener = debugListener;
+		if (mMraidController != null) {
+			mMraidController.setDebugListener(debugListener);
+		}
+	}
 }

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/AdViewController.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/AdViewController.java
@@ -24,6 +24,7 @@ import com.mopub.common.logging.MoPubLog;
 import com.mopub.common.util.DeviceUtils;
 import com.mopub.common.util.Dips;
 import com.mopub.common.util.Utils;
+import com.mopub.mobileads.events.AdCreativeIdBundle;
 import com.mopub.mraid.MraidNativeCommandHandler;
 import com.mopub.network.AdRequest;
 import com.mopub.network.AdResponse;
@@ -66,6 +67,7 @@ public class AdViewController {
 	@Nullable private MoPubView mMoPubView;
 	@Nullable private WebViewAdUrlGenerator mUrlGenerator;
 	
+	@Nullable private AdCreativeIdBundle mAdCreativeIdBundle;
 	@Nullable private AdResponse mAdResponse;
 	@Nullable private String mCustomEventClassName;
 	private final Runnable mRefreshRunnable;
@@ -365,6 +367,11 @@ public class AdViewController {
 		return 0;
 	}
 	
+	@Nullable
+	public AdCreativeIdBundle getAdCreativeIdBundle() {
+		return mAdCreativeIdBundle;
+	}
+	
 	/**
 	 * This has been renamed to {@link #getCurrentAutoRefreshStatus()}.
 	 */
@@ -585,6 +592,10 @@ public class AdViewController {
 				}
 			}
 		});
+	}
+	
+	void setAdCreativeId(AdCreativeIdBundle adCreativeId){
+		mAdCreativeIdBundle = adCreativeId;
 	}
 	
 	private FrameLayout.LayoutParams getAdLayoutParams(View view) {

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/MoPubView.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/MoPubView.java
@@ -19,7 +19,7 @@ import com.mopub.common.util.ManifestUtils;
 import com.mopub.common.util.Reflection;
 import com.mopub.common.util.TrackedContext;
 import com.mopub.common.util.Visibility;
-import com.mopub.mobileads.factories.AdViewControllerFactory;
+import com.mopub.mobileads.events.AdCreativeIdBundle;import com.mopub.mobileads.factories.AdViewControllerFactory;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -443,6 +443,10 @@ public class MoPubView extends FrameLayout {
 
     public void setAdContentView(View view) {
         if (mAdViewController != null) mAdViewController.setAdContentView(view);
+    }
+    
+    public void setAdCreativeId(AdCreativeIdBundle creativeId) {
+        if (mAdViewController != null) mAdViewController.setAdCreativeId(creativeId);
     }
 
     public void setTesting(boolean testing) {

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/events/AdCreativeIdBundle.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/events/AdCreativeIdBundle.java
@@ -1,0 +1,11 @@
+package com.mopub.mobileads.events;
+
+/**
+ * Created by Shad on 30/09/2017.
+ */
+
+public interface AdCreativeIdBundle {
+	
+	String toStringReport();
+	
+}

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/events/MopubAdCreativeId.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/events/MopubAdCreativeId.java
@@ -1,0 +1,21 @@
+package com.mopub.mobileads.events;
+
+/**
+ * Created by Shad on 30/09/2017.
+ */
+
+public class MopubAdCreativeId implements AdCreativeIdBundle {
+	
+	private String mDspCreativeID;
+	
+	public MopubAdCreativeId(final String dspCreativeID) {
+		mDspCreativeID = dspCreativeID;
+	}
+	
+	
+	@Override
+	public String toStringReport() {
+		return String.format("DSPCreativeId=%s", mDspCreativeID);
+	}
+	
+}


### PR DESCRIPTION
Теперь вся реклама может передавать id непосредственной рекламной кампании (creativeId). Из-за того, что у каждой сети формат этой штуки свой, приходится максимально абстрагироваться и представлять все в виде строки. Есть пока для openX, millenial и mopub (html и mraid)