### PR TITLE
Ia 4590 fix memory

### DIFF
--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/ClientMetadata.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/ClientMetadata.java
@@ -142,7 +142,7 @@ public class ClientMetadata {
     public ClientMetadata(Context context) {
         mContext = context.getApplicationContext();
         mConnectivityManager =
-                (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+                (ConnectivityManager) mContext.getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
         mDeviceManufacturer = Build.MANUFACTURER;
         mDeviceModel = Build.MODEL;
         mDeviceProduct = Build.PRODUCT;
@@ -165,7 +165,7 @@ public class ClientMetadata {
         }
 
         final TelephonyManager telephonyManager =
-                (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
+                (TelephonyManager) mContext.getApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
         mNetworkOperatorForUrl = telephonyManager.getNetworkOperator();
         mNetworkOperator = telephonyManager.getNetworkOperator();
         if (telephonyManager.getPhoneType() == TelephonyManager.PHONE_TYPE_CDMA &&

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/LocationService.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/LocationService.java
@@ -154,7 +154,7 @@ public class LocationService {
         }
 
         final LocationManager locationManager =
-                (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+                (LocationManager) context.getApplicationContext().getSystemService(Context.LOCATION_SERVICE);
         try {
             // noinspection ResourceType
             return locationManager.getLastKnownLocation(provider.toString());

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/util/DeviceUtils.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/util/DeviceUtils.java
@@ -33,9 +33,9 @@ import static android.Manifest.permission.INTERNET;
 import static com.mopub.common.util.Reflection.MethodBuilder;
 
 public class DeviceUtils {
-    private static final int MAX_MEMORY_CACHE_SIZE = 30 * 1024 * 1024; // 30 MB
-    private static final int MIN_DISK_CACHE_SIZE = 30 * 1024 * 1024; // 30 MB
-    private static final int MAX_DISK_CACHE_SIZE = 100 * 1024 * 1024; // 100 MB
+    private static final int MAX_MEMORY_CACHE_SIZE = 12 * 1024 * 1024; // 12 MB
+    private static final int MIN_DISK_CACHE_SIZE = 10 * 1024 * 1024; // 10 MB
+    private static final int MAX_DISK_CACHE_SIZE = 40 * 1024 * 1024; // 40 MB
 
     private DeviceUtils() {}
 

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/util/DeviceUtils.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/util/DeviceUtils.java
@@ -84,7 +84,7 @@ public class DeviceUtils {
         // Otherwise, perform the connectivity check.
         try {
             final ConnectivityManager connnectionManager =
-                    (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+                    (ConnectivityManager) context.getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
             final NetworkInfo networkInfo = connnectionManager.getActiveNetworkInfo();
             return networkInfo.isConnected();
         } catch (NullPointerException e) {
@@ -93,7 +93,7 @@ public class DeviceUtils {
     }
 
     public static int memoryCacheSizeBytes(final Context context) {
-        final ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        final ActivityManager activityManager = (ActivityManager) context.getApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
         long memoryClass = activityManager.getMemoryClass();
 
         try {
@@ -173,7 +173,7 @@ public class DeviceUtils {
             return;
         }
 
-        Display display = ((WindowManager) activity.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
+        Display display = ((WindowManager) activity.getApplicationContext().getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
         final int currentRotation = display.getRotation();
         final int deviceOrientation = activity.getResources().getConfiguration().orientation;
 
@@ -213,7 +213,7 @@ public class DeviceUtils {
         Integer bestWidthPixels = null;
         Integer bestHeightPixels = null;
 
-        final WindowManager windowManager = (WindowManager) context.getSystemService(
+        final WindowManager windowManager = (WindowManager) context.getApplicationContext().getSystemService(
                 Context.WINDOW_SERVICE);
         final Display display = windowManager.getDefaultDisplay();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/util/DeviceUtils.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/util/DeviceUtils.java
@@ -33,7 +33,7 @@ import static android.Manifest.permission.INTERNET;
 import static com.mopub.common.util.Reflection.MethodBuilder;
 
 public class DeviceUtils {
-    private static final int MAX_MEMORY_CACHE_SIZE = 12 * 1024 * 1024; // 12 MB
+    private static final int MAX_MEMORY_CACHE_SIZE = 6 * 1024 * 1024; // 12 MB
     private static final int MIN_DISK_CACHE_SIZE = 10 * 1024 * 1024; // 10 MB
     private static final int MAX_DISK_CACHE_SIZE = 40 * 1024 * 1024; // 40 MB
 

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/AdViewController.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/AdViewController.java
@@ -567,7 +567,7 @@ public class AdViewController {
 		
 		// Otherwise, perform the connectivity check.
 		ConnectivityManager cm
-				= (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+				= (ConnectivityManager) mContext.getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
 		NetworkInfo networkInfo = cm.getActiveNetworkInfo();
 		return networkInfo != null && networkInfo.isConnected();
 	}

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/BaseVideoPlayerActivity.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/BaseVideoPlayerActivity.java
@@ -82,7 +82,7 @@ public class BaseVideoPlayerActivity extends Activity {
 
         // VideoViews may never release audio focus, leaking the activity. See
         // https://code.google.com/p/android/issues/detail?id=152173.
-        AudioManager am = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        AudioManager am = (AudioManager) getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
         if (am != null) {
             am.abandonAudioFocus(null);
         }

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/BaseWebView.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/BaseWebView.java
@@ -119,7 +119,7 @@ public class BaseWebView extends WebView {
             params.format = PixelFormat.TRANSPARENT;
             params.gravity = Gravity.START | Gravity.TOP;
             final WindowManager windowManager =
-                    (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+                    (WindowManager) context.getApplicationContext().getSystemService(Context.WINDOW_SERVICE);
 
             windowManager.addView(webView, params);
         }

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mraid/MraidController.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mraid/MraidController.java
@@ -357,7 +357,7 @@ public class MraidController {
     // onPageLoaded gets fired once the html is loaded into the webView.
     private int getDisplayRotation() {
         WindowManager wm = (WindowManager) mContext
-                .getSystemService(Context.WINDOW_SERVICE);
+                .getApplicationContext().getSystemService(Context.WINDOW_SERVICE);
         return wm.getDefaultDisplay().getRotation();
     }
 

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/network/MaxWidthImageLoader.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/network/MaxWidthImageLoader.java
@@ -15,7 +15,7 @@ public class MaxWidthImageLoader extends com.mopub.volley.toolbox.ImageLoader {
         super(queue, imageCache);
 
         // Get Display Options
-        WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        WindowManager wm = (WindowManager) context.getApplicationContext().getSystemService(Context.WINDOW_SERVICE);
         Display display = wm.getDefaultDisplay();
         Point size = new Point();
         display.getSize(size);


### PR DESCRIPTION
Используем контекст приложения вместо активити для получения системных сервисов для предотвращения ликов.  А еще уменьшил размер in-memory кэша для картинок внутри мопаба