### PR TITLE
IA-4875 use application context for native ad

### DIFF
--- a/mopub-sdk/mopub-sdk-native-static/src/main/java/com/mopub/nativeads/MoPubNative.java
+++ b/mopub-sdk/mopub-sdk-native-static/src/main/java/com/mopub/nativeads/MoPubNative.java
@@ -1,3 +1,4 @@
+//@formatter:off
 package com.mopub.nativeads;
 
 import android.content.Context;
@@ -98,7 +99,7 @@ public class MoPubNative {
 
 		setBannedAdapters(bannedAdapters);
 
-		mContext = new WeakReference<Context>(context);
+		mContext = new WeakReference<Context>(context.getApplicationContext());
 		mAdUnitId = adUnitId;
 		mMoPubNativeNetworkListener = moPubNativeNetworkListener;
 		mAdRendererRegistry = adRendererRegistry;


### PR DESCRIPTION
Используем application context в нативной рекламе теперь. Ни на что повлиять не должно, вроде. Ну кроме возможности что-то ликнуть