### PR TITLE
IA-5061 cancel timeouts for invalidated banners

### DIFF
--- a/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/CustomEventBannerAdapter.java
+++ b/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/CustomEventBannerAdapter.java
@@ -126,6 +126,8 @@ public class CustomEventBannerAdapter implements CustomEventBannerListener {
 				MoPubLog.d("Destroying a banner visibility tracker threw an exception", e);
 			}
 		}
+		
+		cancelTimeout();
 		mContext = null;
 		mCustomEventBanner = null;
 		mLocalExtras = null;


### PR DESCRIPTION
Отмена определение таймаута загрузки баннера по любому событию с ним (сейчас только по успешной загрузке или незагрузке, при уничтожении таймаута не было)

QA
Проверить, что реклама перезагружается после ухода в фон/поворотов. Особенно c dontKeepActivities